### PR TITLE
Fix animation in `quickstart.ipynb`

### DIFF
--- a/tdgl/solution/data.py
+++ b/tdgl/solution/data.py
@@ -14,7 +14,7 @@ from ..geometry import path_vectors
 def get_data_range(h5file: h5py.File) -> Tuple[int, int]:
     """Returns the minimum and maximum solve steps in the file."""
     keys = np.asarray([int(key) for key in h5file["data"]])
-    return np.min(keys), np.max(keys)
+    return int(np.min(keys)), int(np.max(keys))
 
 
 def load_state_data(h5file: h5py.File, step: int) -> Dict[str, Any]:


### PR DESCRIPTION
Computing the animations in the `docs/notebooks/quickstart.ipynb` fails with numpy 2.0.

With the attached change, the animations are computed correctly.

Hypothesis: This seems to originate from matplotlib creating `collection.deque` where a numpy int is passed as the `maxlen` argument. From numpy 2 onwards, this needs to be a plain python int for deque not to complain.

